### PR TITLE
Improve markdownToHtml: refine plugin usage and HTML rendering

### DIFF
--- a/src/lib/markdownToHtml.js
+++ b/src/lib/markdownToHtml.js
@@ -3,7 +3,7 @@ import html from "remark-html";
 import gfm from "remark-gfm";
 import prism from "remark-prism";
 import externalLinks from "remark-external-links";
-import highlight from "remark-highlight.js";
+// import highlight from "remark-highlight.js";
 
 export default async function markdownToHtml(markdown) {
   const result = await remark()

--- a/src/lib/markdownToHtml.js
+++ b/src/lib/markdownToHtml.js
@@ -6,6 +6,12 @@ import externalLinks from "remark-external-links";
 import highlight from "remark-highlight.js";
 
 export default async function markdownToHtml(markdown) {
-  const result = await remark().use(externalLinks).use(highlight).use(html).use(gfm).use(prism).process(markdown);
+  const result = await remark()
+    .use(externalLinks)
+    // .use(highlight)
+    .use(html, { sanitize: false })
+    .use(gfm)
+    .use(prism)
+    .process(markdown);
   return result.toString();
 }


### PR DESCRIPTION
This pull request updates the `markdownToHtml` function to improve HTML rendering and plugin usage. The most important changes are grouped below:

**Markdown processing improvements:**

* Disabled the `remark-highlight.js` plugin by commenting out its import and usage, likely to resolve conflicts or improve compatibility with other plugins.
* Updated the `remark-html` plugin usage to explicitly set the `sanitize` option to `false`, allowing for richer HTML output from markdown content.